### PR TITLE
Mark mojo as not requiring a project.

### DIFF
--- a/m2cachecleanup/src/main/java/ch/ringler/tools/m2cachecleanup/CleanupMavenCache.java
+++ b/m2cachecleanup/src/main/java/ch/ringler/tools/m2cachecleanup/CleanupMavenCache.java
@@ -30,7 +30,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * Maven cache
  * 
  */
-@Mojo(name = "cleanup-cache", defaultPhase = LifecyclePhase.CLEAN)
+@Mojo(name = "cleanup-cache", defaultPhase = LifecyclePhase.CLEAN, requiresProject = false)
 public class CleanupMavenCache extends AbstractMojo {
 	/**
 	 * Location of the file.


### PR DESCRIPTION
This is to enable standalone execution of the plugin
